### PR TITLE
Update SN2011fe.json

### DIFF
--- a/SN2011fe.json
+++ b/SN2011fe.json
@@ -4,6 +4,16 @@
     "aliases":[
       "SN2011fe",
       "PTF11kly"
+    ],
+    "spectra":[
+      {
+        "filename":"2011fe_20140623_MODS1.dat",
+        "display":["3320.","9910."]
+      },
+      {
+        "filename":"PTF11kly.LRIS.20140501.ms.ReduxB.dat",
+        "display":["3400.","10000."]
+      }
     ]
   }
 }

--- a/SN2011fe.json
+++ b/SN2011fe.json
@@ -8,11 +8,33 @@
     "spectra":[
       {
         "filename":"2011fe_20140623_MODS1.dat",
-        "display":["3320.","9910."]
+        "exclude":[
+          {
+            "range":[3320.],
+            "reason":"noise",
+            "cut":"below"
+          },
+          {
+            "range":[9910.],
+            "reason":"noise",
+            "cut":"above"
+          }
+        ]
       },
       {
         "filename":"PTF11kly.LRIS.20140501.ms.ReduxB.dat",
-        "display":["3400.","10000."]
+        "exclude":[
+          {
+            "range":[3400.],
+            "reason":"noise",
+            "cut":"below"
+          },
+          {
+            "range":[10000.],
+            "reason":"noise",
+            "cut":"above"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Pardon the delay.

OK so what I've done here is add in the display attribute assuming the spectrum is shown between 3320 and 9910 Angstroms for the first spectrum in need of trimming. This should be used to cut/grey-out everything blueward of 3320 Ang and redward of 9910 Ang. Alternatively I could create two display windows that specify a window to cut, one in the blue, one in the red. 

Side notes: 
--I've specified the filename for each spectrum in order to identify which display window goes where. Thoughts?
--In order to get the spectrum to show up with a better scaling, is it possible to normalize wrt the "new" spectrum's wavelength range?
--We could instead do "blue", "red", "cosmic/spike" to cut any cosmic ray spikes and/or else.
