### PR TITLE
SN2013ak's claimedtype from 2013ATel.4874....1M,Transient Name Server…

### DIFF
--- a/SN2013ak.json
+++ b/SN2013ak.json
@@ -3,15 +3,11 @@
 		"name":"SN2013ak",
 		"sources":[
       			{
-        		"name":"2013ATel.4943....1M",
-        		"url":"http://adsabs.harvard.edu/abs/2013ATel.4943....1M",
-        		"bibcode":"2013ATel.4943....1M",
-        		"alias":"1"
+        			"bibcode":"2013ATel.4943....1M"
       			}],
 		"claimedtype":[
       			{
-			"value":"IIb",
-        		"source":"2"
+				"value":"IIb"
       			}
     			],
 		"errors":[

--- a/SN2013ak.json
+++ b/SN2013ak.json
@@ -2,18 +2,18 @@
 	"SN2013ak":{
 		"name":"SN2013ak",
 		"sources":[
-      {
-        "name":"2013ATel.4943....1M",
-        "url":"http://adsabs.harvard.edu/abs/2013ATel.4943....1M",
-        "bibcode":"2013ATel.4943....1M",
-        "alias":"1"
-      },
+      			{
+        		"name":"2013ATel.4943....1M",
+        		"url":"http://adsabs.harvard.edu/abs/2013ATel.4943....1M",
+        		"bibcode":"2013ATel.4943....1M",
+        		"alias":"1"
+      			}],
 		"claimedtype":[
-      {
-        "value":"IIb",
-        "source":"2"
-      }
-    ],
+      			{
+			"value":"IIb",
+        		"source":"2"
+      			}
+    			],
 		"errors":[
 			{
 				"value":"2013ATel.4874....1M",

--- a/SN2013ak.json
+++ b/SN2013ak.json
@@ -1,0 +1,25 @@
+{
+	"SN2013ak":{
+		"name":"SN2013ak",
+		"sources":[
+      {
+        "name":"2013ATel.4943....1M",
+        "url":"http://adsabs.harvard.edu/abs/2013ATel.4943....1M",
+        "bibcode":"2013ATel.4943....1M",
+        "alias":"1"
+      },
+		"claimedtype":[
+      {
+        "value":"IIb",
+        "source":"2"
+      }
+    ],
+		"errors":[
+			{
+				"value":"2013ATel.4874....1M",
+				"kind":"bibcode",
+				"extra":"claimedtype"
+			},
+		]
+	}
+}


### PR DESCRIPTION
…,2000A&AS..143....9W marked as being erroneous.

This telegramby Milasalevich+ (2013ATel.4943....1M) classifying Sn 2013ak as IIb superseeds the earliermoregenericclassification as type II also by Milasalevich+ (2013ATel.4874....1M)
