### PR TITLE
SN2003jn's dec from Transient Name Server marked as being erroneous.

### DIFF
--- a/SN2003jn.json
+++ b/SN2003jn.json
@@ -10,4 +10,3 @@
 		]
 	}
 }
-### IAUC 8237 dec coordinates have incorrect sign.

--- a/SN2003jn.json
+++ b/SN2003jn.json
@@ -1,0 +1,13 @@
+{
+	"SN2003jn":{
+		"name":"SN2003jn",
+		"errors":[
+			{
+				"value":"Transient Name Server",
+				"kind":"name",
+				"extra":"dec"
+			}
+		]
+	}
+}
+### IAUC 8237 dec coordinates have incorrect sign.


### PR DESCRIPTION
IAUC 8237 dec coordinates have incorrect sign.
