### PR TITLE
SN1983J's claimedtype from 2013MNRAS.433L..20M,2000A&AS..143....9W ma…

### DIFF
--- a/SN1983J.json
+++ b/SN1983J.json
@@ -1,0 +1,17 @@
+{
+	"SN1983J":{
+		"name":"SN1983J",
+		"errors":[
+			{
+				"value":"2013MNRAS.433L..20M",
+				"kind":"bibcode",
+				"extra":"Unknown"
+			},
+			{
+				"value":"2000A&AS..143....9W",
+				"kind":"bibcode",
+				"extra":"Unknown"
+			}
+		]
+	}
+}

--- a/SN1983J.json
+++ b/SN1983J.json
@@ -5,12 +5,12 @@
 			{
 				"value":"2013MNRAS.433L..20M",
 				"kind":"bibcode",
-				"extra":"Unknown"
+				"extra":"claimedtype"
 			},
 			{
 				"value":"2000A&AS..143....9W",
 				"kind":"bibcode",
-				"extra":"Unknown"
+				"extra":"claimedtype"
 			}
 		]
 	}


### PR DESCRIPTION
…rked as being erroneous.

2013MNRAS.433L..20M mention SN1983J, but the actual SN is 1983G, so 83J remains untyped