### PR TITLE
SN837A: mark wrong discoverdate

### DIFF
--- a/SN837A.json
+++ b/SN837A.json
@@ -42,6 +42,13 @@
 				"e_value":"21600",
 				"source":"1"
 			}
+		],
+		"errors":[
+			{
+				"value":"2009JHA....40...31S",
+				"kind":"bibcode",
+				"extra":"discoverdate"
+			}
 		]
 	}
 }


### PR DESCRIPTION
SN837A can’t have been discovered in the year 369, i.e. 468 years before it happened