### PR TITLE
Update iPTF16asu.json

### DIFF
--- a/iPTF16asu.json
+++ b/iPTF16asu.json
@@ -19,6 +19,12 @@
 				"source":"1"
 			}
 		],
+		"claimedtype":[
+			{
+				"value":"Ic BL",
+				"source":"1"
+			}
+		],
 		"photometry":[
 			{
 				"time":"57519.26",


### PR DESCRIPTION
iPTF16asu was classified by Whitesides et al. (2017) as a broad-lined Ic supernova. I have added this classification under "claimed type."