### PR TITLE
Update SN2005fk.json

### DIFF
--- a/SN2005fk.json
+++ b/SN2005fk.json
@@ -5,19 +5,19 @@
 			{
 				"value":"SN2005fk"
 			}
-    ]
-    "sources":[
-	    {
-		    "name":"Taddia et al. (2015)",
-		    "bibcode":"2015A%26A...574A..60T",
-		    "alias":"15"
-	    }
-    ]
-    "claimedtype":[
-      {
-        "value":"Ic BL",
+    		],
+    		"sources":[
+	    		{
+		    		"name":"Taddia et al. (2015)",
+		    		"bibcode":"2015A%26A...574A..60T",
+		    		"alias":"15"
+	    		}
+    		],
+    		"claimedtype":[
+      			{
+        			"value":"Ic BL",
 				"source":"15"
-      }
-    ]
+      			}
+    		]
 	}
 }

--- a/SN2005fk.json
+++ b/SN2005fk.json
@@ -1,0 +1,23 @@
+{
+	"SN2005fk":{
+		"name":"SN2005fk",
+		"alias":[
+			{
+				"value":"SN2005fk"
+			}
+    ]
+    "sources":[
+	    {
+		    "name":"Taddia et al. (2015)",
+		    "bibcode":"2015A%26A...574A..60T",
+		    "alias":"15"
+	    }
+    ]
+    "claimedtype":[
+      {
+        "value":"Ic BL",
+				"source":"15"
+      }
+    ]
+	}
+}


### PR DESCRIPTION
SN2005fk received as Ic-BL classification in Taddia et al. (2015). I have added this classification as well as the reference. When I clicked "edit" on the homepage I was taken to creating this new .json page, though, instead of editing an existing one -- I am not sure why that is.