### PR TITLE
Update SN2005kr.json

### DIFF
--- a/SN2005kr.json
+++ b/SN2005kr.json
@@ -1,0 +1,22 @@
+{
+	"SN2005kr":{
+		"name":"SN2005kr",
+		"alias":[
+			{
+				"value":"SN2005kr"
+			}
+		],
+		"sources":[
+			{
+				"bibcode":"2015A%26A...574A..60T",
+				"alias":"15"
+			}
+		],
+		"claimedtype":[
+			{
+				"value":"Ic BL",
+				"source":"15"
+			}
+		]
+	}
+}

--- a/SN2005kr.json
+++ b/SN2005kr.json
@@ -15,7 +15,7 @@
 		"claimedtype":[
 			{
 				"value":"Ic BL",
-				"source":"15"
+				"source":"1"
 			}
 		]
 	}

--- a/SN2005kr.json
+++ b/SN2005kr.json
@@ -8,7 +8,7 @@
 		],
 		"sources":[
 			{
-				"bibcode":"2015A%26A...574A..60T",
+				"bibcode":"2015A&A...574A..60T",
 				"alias":"15"
 			}
 		],

--- a/SN2005kr.json
+++ b/SN2005kr.json
@@ -9,7 +9,7 @@
 		"sources":[
 			{
 				"bibcode":"2015A&A...574A..60T",
-				"alias":"15"
+				"alias":"1"
 			}
 		],
 		"claimedtype":[


### PR DESCRIPTION
SN2005kr was classified as Type Ic-BL in Taddia (2015). I have added both the classification and the reference.