### PR TITLE
Update SN2009dr.json

### DIFF
--- a/SN2009dr.json
+++ b/SN2009dr.json
@@ -1,0 +1,23 @@
+{
+	"SN2009dr":{
+		"name":"SN2009dr",
+		"alias":[
+			{
+				"value":"SN2009dr"
+			}
+		],
+    "sources":[
+      {
+        "name":"Prentice et al. (2016)",
+        "bibcode":"2016MNRAS.458.2973P",
+        "alias":"1"
+      }
+    ],
+    "claimedtype":[
+      {
+        "value":"Ic BL",
+        "source":"1"
+      }
+    ]
+	}
+}


### PR DESCRIPTION
This reference states that the original SN Ia classification was an error, and that the correct type is Ic BL.